### PR TITLE
Streaming wire transfer with concurrent generator/receiver pipeline

### DIFF
--- a/crates/ferrosync-core/src/delta/checksum.rs
+++ b/crates/ferrosync-core/src/delta/checksum.rs
@@ -135,6 +135,91 @@ pub fn file_checksum(data: &[u8], _seed: i32, checksum_type: ChecksumType) -> Ve
     }
 }
 
+/// Incremental file-level checksum for streaming verification.
+///
+/// Wraps the same hash algorithms as [`file_checksum`] but supports
+/// incremental `update` calls followed by a single `finalize`.
+/// This allows computing the file checksum without buffering the
+/// entire file in memory.
+#[allow(clippy::large_enum_variant)]
+pub enum IncrementalChecksum {
+    Md4(md4::Md4),
+    Md5(md5::Md5),
+    Blake3(Box<blake3::Hasher>),
+    Xxh3(xxhash_rust::xxh3::Xxh3),
+    Xxh128(xxhash_rust::xxh3::Xxh3),
+    None(usize),
+}
+
+impl IncrementalChecksum {
+    /// Create a new incremental checksum for the given algorithm.
+    pub fn new(checksum_type: ChecksumType) -> Self {
+        match checksum_type {
+            ChecksumType::Md4 => {
+                use md4::Digest;
+                IncrementalChecksum::Md4(md4::Md4::new())
+            }
+            ChecksumType::Md5 => {
+                use md5::Digest;
+                IncrementalChecksum::Md5(md5::Md5::new())
+            }
+            ChecksumType::Blake3 => IncrementalChecksum::Blake3(Box::new(blake3::Hasher::new())),
+            ChecksumType::Xxh3 => {
+                IncrementalChecksum::Xxh3(xxhash_rust::xxh3::Xxh3::new())
+            }
+            ChecksumType::Xxh128 => {
+                IncrementalChecksum::Xxh128(xxhash_rust::xxh3::Xxh3::new())
+            }
+            ChecksumType::None => IncrementalChecksum::None(checksum_type.digest_len()),
+        }
+    }
+
+    /// Feed more data into the checksum.
+    pub fn update(&mut self, data: &[u8]) {
+        match self {
+            IncrementalChecksum::Md4(h) => {
+                use md4::Digest;
+                h.update(data);
+            }
+            IncrementalChecksum::Md5(h) => {
+                use md5::Digest;
+                h.update(data);
+            }
+            IncrementalChecksum::Blake3(h) => {
+                h.update(data);
+            }
+            IncrementalChecksum::Xxh3(h) | IncrementalChecksum::Xxh128(h) => {
+                h.update(data);
+            }
+            IncrementalChecksum::None(_) => {}
+        }
+    }
+
+    /// Finalize and return the digest bytes.
+    pub fn finalize(self) -> Vec<u8> {
+        match self {
+            IncrementalChecksum::Md4(h) => {
+                use md4::Digest;
+                h.finalize().to_vec()
+            }
+            IncrementalChecksum::Md5(h) => {
+                use md5::Digest;
+                h.finalize().to_vec()
+            }
+            IncrementalChecksum::Blake3(h) => h.finalize().as_bytes().to_vec(),
+            IncrementalChecksum::Xxh3(h) => {
+                let hash = h.digest();
+                hash.to_le_bytes().to_vec()
+            }
+            IncrementalChecksum::Xxh128(h) => {
+                let hash = h.digest128();
+                hash.to_le_bytes().to_vec()
+            }
+            IncrementalChecksum::None(len) => vec![0; len],
+        }
+    }
+}
+
 /// State for an incremental rolling checksum that can be updated byte-by-byte
 /// as a window slides over the data.
 #[derive(Debug, Clone)]
@@ -417,5 +502,66 @@ mod tests {
         let c1 = file_checksum(b"data", 1, ChecksumType::Xxh128);
         let c2 = file_checksum(b"data", 999, ChecksumType::Xxh128);
         assert_eq!(c1, c2);
+    }
+
+    // -----------------------------------------------------------------------
+    // IncrementalChecksum tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_incremental_matches_batch_md5() {
+        let data = b"hello world, this is a test of incremental checksumming";
+        let batch = file_checksum(data, 0, ChecksumType::Md5);
+        let mut inc = IncrementalChecksum::new(ChecksumType::Md5);
+        inc.update(&data[..10]);
+        inc.update(&data[10..30]);
+        inc.update(&data[30..]);
+        assert_eq!(inc.finalize(), batch);
+    }
+
+    #[test]
+    fn test_incremental_matches_batch_blake3() {
+        let data = b"blake3 incremental test data";
+        let batch = file_checksum(data, 0, ChecksumType::Blake3);
+        let mut inc = IncrementalChecksum::new(ChecksumType::Blake3);
+        inc.update(&data[..5]);
+        inc.update(&data[5..]);
+        assert_eq!(inc.finalize(), batch);
+    }
+
+    #[test]
+    fn test_incremental_matches_batch_xxh3() {
+        let data = b"xxh3 incremental test data";
+        let batch = file_checksum(data, 0, ChecksumType::Xxh3);
+        let mut inc = IncrementalChecksum::new(ChecksumType::Xxh3);
+        inc.update(&data[..8]);
+        inc.update(&data[8..]);
+        assert_eq!(inc.finalize(), batch);
+    }
+
+    #[test]
+    fn test_incremental_matches_batch_xxh128() {
+        let data = b"xxh128 incremental test data";
+        let batch = file_checksum(data, 0, ChecksumType::Xxh128);
+        let mut inc = IncrementalChecksum::new(ChecksumType::Xxh128);
+        inc.update(&data[..12]);
+        inc.update(&data[12..]);
+        assert_eq!(inc.finalize(), batch);
+    }
+
+    #[test]
+    fn test_incremental_matches_batch_md4() {
+        let data = b"md4 incremental test data";
+        let batch = file_checksum(data, 0, ChecksumType::Md4);
+        let mut inc = IncrementalChecksum::new(ChecksumType::Md4);
+        inc.update(data);
+        assert_eq!(inc.finalize(), batch);
+    }
+
+    #[test]
+    fn test_incremental_empty_data() {
+        let batch = file_checksum(b"", 0, ChecksumType::Md5);
+        let inc = IncrementalChecksum::new(ChecksumType::Md5);
+        assert_eq!(inc.finalize(), batch);
     }
 }

--- a/crates/ferrosync-core/src/engine/receiver.rs
+++ b/crates/ferrosync-core/src/engine/receiver.rs
@@ -173,6 +173,89 @@ pub async fn recv_file_delta_compressed<R: AsyncRead + Unpin>(
     Ok(output)
 }
 
+/// Receive tokens and reconstruct a file, writing output to a writer.
+///
+/// Same delta reconstruction as [`recv_file_delta`] but writes data
+/// incrementally to `writer` instead of buffering in memory. The file
+/// checksum is computed incrementally as data is written.
+///
+/// Returns the number of bytes written.
+pub async fn recv_file_delta_to_writer<R: AsyncRead + Unpin, W: std::io::Write>(
+    r: &mut R,
+    basis_data: &[u8],
+    blength: usize,
+    _seed: i32,
+    checksum_type: ChecksumType,
+    writer: &mut W,
+) -> Result<u64> {
+    let mut hasher = checksum::IncrementalChecksum::new(checksum_type);
+    let mut bytes_written = 0u64;
+
+    let block_count = if blength > 0 && !basis_data.is_empty() {
+        basis_data.len().div_ceil(blength)
+    } else {
+        0
+    };
+    #[allow(clippy::manual_is_multiple_of)]
+    let remainder = if blength > 0 && !basis_data.is_empty() && basis_data.len() % blength != 0 {
+        basis_data.len() % blength
+    } else {
+        blength
+    };
+
+    loop {
+        match token::recv_token(r).await? {
+            Token::Data(data) => {
+                hasher.update(&data);
+                writer.write_all(&data).map_err(|e| {
+                    ProtocolError::Io(std::sync::Arc::new(e))
+                })?;
+                bytes_written += data.len() as u64;
+            }
+            Token::BlockMatch(idx) => {
+                let idx = idx as usize;
+                let offset = idx * blength;
+                let len = if block_count > 0
+                    && idx == block_count - 1
+                    && remainder > 0
+                    && remainder < blength
+                {
+                    remainder
+                } else {
+                    blength
+                };
+                let end = (offset + len).min(basis_data.len());
+                if offset < basis_data.len() {
+                    let slice = &basis_data[offset..end];
+                    hasher.update(slice);
+                    writer.write_all(slice).map_err(|e| {
+                        ProtocolError::Io(std::sync::Arc::new(e))
+                    })?;
+                    bytes_written += slice.len() as u64;
+                }
+            }
+            Token::EndOfFile => break,
+        }
+    }
+
+    // Read and verify file-level checksum.
+    let digest_len = checksum_type.digest_len();
+    let mut received_checksum = vec![0u8; digest_len];
+    r.read_exact(&mut received_checksum)
+        .await
+        .map_err(ProtocolError::from)?;
+
+    let computed_checksum = hasher.finalize();
+    if received_checksum != computed_checksum {
+        return Err(ProtocolError::ChecksumMismatch {
+            expected: hex_encode(&received_checksum),
+            actual: hex_encode(&computed_checksum),
+        });
+    }
+
+    Ok(bytes_written)
+}
+
 fn hex_encode(bytes: &[u8]) -> String {
     use std::fmt::Write;
     bytes.iter().fold(String::new(), |mut s, b| {
@@ -333,5 +416,145 @@ mod tests {
         let mut cursor = Cursor::new(&buf);
         let idx = recv_file_index(&mut cursor).await.unwrap();
         assert_eq!(idx, None);
+    }
+
+    #[tokio::test]
+    async fn test_recv_file_delta_to_writer_new_file() {
+        let source = b"hello world, this is new data!";
+        let seed = 42;
+        let sums = sum::compute_signatures(
+            b"",
+            seed,
+            ChecksumType::Md5,
+            checksum::CHAR_OFFSET_V30,
+            true,
+        );
+
+        let mut buf = Vec::new();
+        sender::send_file_delta_with_sums(&mut buf, 0, source, &sums, seed, ChecksumType::Md5)
+            .await
+            .unwrap();
+
+        let mut cursor = Cursor::new(&buf);
+        let idx = recv_file_index(&mut cursor).await.unwrap();
+        assert_eq!(idx, Some(0));
+
+        let blength = if sums.head.blength > 0 {
+            sums.head.blength as usize
+        } else {
+            700
+        };
+
+        let mut output = Vec::new();
+        let bytes = recv_file_delta_to_writer(
+            &mut cursor,
+            b"",
+            blength,
+            seed,
+            ChecksumType::Md5,
+            &mut output,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(output, source);
+        assert_eq!(bytes, source.len() as u64);
+    }
+
+    #[tokio::test]
+    async fn test_recv_file_delta_to_writer_modified_file() {
+        let mut basis = vec![0u8; 5000];
+        for (i, b) in basis.iter_mut().enumerate() {
+            *b = (i % 256) as u8;
+        }
+        let mut source = basis.clone();
+        source[2500] = 0xFF;
+        source[2501] = 0xFF;
+
+        let seed = 7;
+        let sums = sum::compute_signatures(
+            &basis,
+            seed,
+            ChecksumType::Md5,
+            checksum::CHAR_OFFSET_V30,
+            true,
+        );
+
+        let mut buf = Vec::new();
+        sender::send_file_delta_with_sums(&mut buf, 3, &source, &sums, seed, ChecksumType::Md5)
+            .await
+            .unwrap();
+
+        let mut cursor = Cursor::new(&buf);
+        let idx = recv_file_index(&mut cursor).await.unwrap();
+        assert_eq!(idx, Some(3));
+
+        let blength = if sums.head.blength > 0 {
+            sums.head.blength as usize
+        } else {
+            700
+        };
+
+        let mut output = Vec::new();
+        recv_file_delta_to_writer(
+            &mut cursor,
+            &basis,
+            blength,
+            seed,
+            ChecksumType::Md5,
+            &mut output,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(output, source);
+    }
+
+    #[tokio::test]
+    async fn test_recv_file_delta_to_writer_matches_buffered() {
+        // Verify streaming and buffered paths produce identical results.
+        let source = b"data that exercises both code paths for correctness";
+        let seed = 99;
+        let sums = sum::compute_signatures(
+            b"",
+            seed,
+            ChecksumType::Blake3,
+            checksum::CHAR_OFFSET_V30,
+            true,
+        );
+
+        let mut buf = Vec::new();
+        sender::send_file_delta_with_sums(&mut buf, 0, source, &sums, seed, ChecksumType::Blake3)
+            .await
+            .unwrap();
+
+        // Buffered path.
+        let mut cursor1 = Cursor::new(&buf);
+        let _ = recv_file_index(&mut cursor1).await.unwrap();
+        let blength = if sums.head.blength > 0 {
+            sums.head.blength as usize
+        } else {
+            700
+        };
+        let buffered = recv_file_delta(&mut cursor1, b"", blength, seed, ChecksumType::Blake3)
+            .await
+            .unwrap();
+
+        // Streaming path.
+        let mut cursor2 = Cursor::new(&buf);
+        let _ = recv_file_index(&mut cursor2).await.unwrap();
+        let mut streamed = Vec::new();
+        recv_file_delta_to_writer(
+            &mut cursor2,
+            b"",
+            blength,
+            seed,
+            ChecksumType::Blake3,
+            &mut streamed,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(buffered, streamed);
     }
 }

--- a/crates/ferrosync-core/src/engine/session.rs
+++ b/crates/ferrosync-core/src/engine/session.rs
@@ -11,6 +11,7 @@
 //! ```
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use tokio::io::AsyncRead;
 
@@ -322,10 +323,11 @@ impl<T: Transport> SyncSession<T> {
         // Keep streams alive so background_task is not aborted.
         let _streams_guard = streams;
 
+        let fs: Arc<dyn FileSystem> = fs.into();
         if am_sender {
             run_push(reader, writer, &protocol, &options, &*fs, &mut progress).await
         } else {
-            run_pull(reader, writer, &protocol, &options, &*fs, &mut progress).await
+            run_pull(reader, writer, &protocol, &options, fs, &mut progress).await
         }
     }
 }
@@ -485,7 +487,7 @@ async fn run_pull(
     writer: Box<dyn tokio::io::AsyncWrite + Unpin + Send>,
     protocol: &NegotiatedProtocol,
     options: &TransferOptions,
-    fs: &dyn FileSystem,
+    fs: Arc<dyn FileSystem>,
     progress: &mut ProgressTracker,
 ) -> Result<TransferResult> {
     let mut stats = TransferStats::new();
@@ -551,20 +553,23 @@ async fn run_pull(
             }
         }
     } else {
-        // Receiver loop via wire_transfer.
-        let file_ops = LocalFileOps::new(fs, &dest, options);
+        // Pipelined receiver loop: generator and receiver run concurrently.
+        let file_ops: Arc<dyn wire_transfer::FileOps> =
+            Arc::new(LocalFileOps::new(Arc::clone(&fs), dest.clone(), options.clone()));
 
-        wire_transfer::receiver_loop(
-            &mut demux_read,
-            &mut mplex_out,
+        let (dr, mo) = wire_transfer::receiver_loop_pipelined(
+            demux_read,
+            mplex_out,
             &entries,
             &entry_ndx,
-            &file_ops,
+            file_ops,
             protocol,
             &mut stats,
             progress,
         )
         .await?;
+        demux_read = dr;
+        mplex_out = mo;
 
         // Handle symlinks (after file transfers).
         for entry in &entries {

--- a/crates/ferrosync-core/src/engine/wire_transfer.rs
+++ b/crates/ferrosync-core/src/engine/wire_transfer.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
 
@@ -162,23 +163,23 @@ pub trait FileOps: Send + Sync {
 }
 
 /// Receiver-side operations using local filesystem with TransferOptions.
-pub struct LocalFileOps<'a> {
-    fs: &'a dyn FileSystem,
-    dest: &'a Path,
-    options: &'a crate::options::TransferOptions,
+pub struct LocalFileOps {
+    fs: Arc<dyn FileSystem>,
+    dest: PathBuf,
+    options: crate::options::TransferOptions,
 }
 
-impl<'a> LocalFileOps<'a> {
+impl LocalFileOps {
     pub fn new(
-        fs: &'a dyn FileSystem,
-        dest: &'a Path,
-        options: &'a crate::options::TransferOptions,
+        fs: Arc<dyn FileSystem>,
+        dest: PathBuf,
+        options: crate::options::TransferOptions,
     ) -> Self {
         Self { fs, dest, options }
     }
 }
 
-impl FileOps for LocalFileOps<'_> {
+impl FileOps for LocalFileOps {
     fn read_basis(&self, entry: &FileEntry) -> Vec<u8> {
         let dest_path = self.dest_path(entry);
         self.fs.read_file(&dest_path).unwrap_or_default()
@@ -191,13 +192,13 @@ impl FileOps for LocalFileOps<'_> {
     ) -> std::result::Result<(), crate::FerrosyncError> {
         let dest_path = self.dest_path(entry);
         super::file_decision::write_file_with_options(
-            self.fs, &dest_path, data, entry, self.options,
+            &*self.fs, &dest_path, data, entry, &self.options,
         )
     }
 
     fn set_metadata(&self, entry: &FileEntry) {
         let dest_path = self.dest_path(entry);
-        super::file_decision::set_file_metadata(self.fs, &dest_path, entry, self.options);
+        super::file_decision::set_file_metadata(&*self.fs, &dest_path, entry, &self.options);
     }
 
     fn mkdir(&self, entry: &FileEntry) -> std::result::Result<(), crate::error::FsError> {
@@ -243,18 +244,18 @@ impl FileOps for LocalFileOps<'_> {
 }
 
 /// Receiver-side operations using module directory (server side).
-pub struct ModuleFileOps<'a> {
-    fs: &'a dyn FileSystem,
-    module_path: &'a Path,
+pub struct ModuleFileOps {
+    fs: Arc<dyn FileSystem>,
+    module_path: PathBuf,
 }
 
-impl<'a> ModuleFileOps<'a> {
-    pub fn new(fs: &'a dyn FileSystem, module_path: &'a Path) -> Self {
+impl ModuleFileOps {
+    pub fn new(fs: Arc<dyn FileSystem>, module_path: PathBuf) -> Self {
         Self { fs, module_path }
     }
 }
 
-impl FileOps for ModuleFileOps<'_> {
+impl FileOps for ModuleFileOps {
     fn read_basis(&self, entry: &FileEntry) -> Vec<u8> {
         let dest_path = self.dest_path(entry);
         self.fs.read_file(&dest_path).unwrap_or_default()
@@ -421,16 +422,17 @@ where
             protocol.proper_seed_order,
         );
 
-        // Build sender response: NDX + iflags + sum_head + tokens + checksum.
-        let mut resp_buf = Vec::new();
+        // Stream sender response: NDX + iflags + sum_head (small header),
+        // then tokens individually, then file checksum.
+        // Each piece goes to the wire as its own MUX frame(s), avoiding
+        // an O(file_size) intermediate buffer.
 
-        // NDX + iflags.
-        varint::write_ndx(&mut resp_buf, ndx, &mut send_ndx_state, proto_ver).await?;
+        // 1. Small header: NDX + iflags + sum_head (~20 bytes).
+        let mut hdr = Vec::with_capacity(64);
+        varint::write_ndx(&mut hdr, ndx, &mut send_ndx_state, proto_ver).await?;
         if proto_ver >= 29 {
-            varint::write_shortint(&mut resp_buf, iflags).await?;
+            varint::write_shortint(&mut hdr, iflags).await?;
         }
-
-        // sum_head: echo back the generator's sum head.
         let resp_sum_head = if sums.head.count == 0 {
             sum::SumHead {
                 count: 0,
@@ -446,33 +448,37 @@ where
                 remainder: sums.head.remainder,
             }
         };
-        sum::write_sum_head(&mut resp_buf, &resp_sum_head).await?;
+        sum::write_sum_head(&mut hdr, &resp_sum_head).await?;
+        mplex_out.write_data(&hdr).await?;
 
-        // Delta tokens.
+        // 2. Stream delta tokens directly to the wire.
         let mut literal_bytes = 0u64;
         let mut matched_bytes = 0u64;
         for op in &ops {
             match op {
                 matcher::MatchOp::Data(data) => {
-                    token::send_data(&mut resp_buf, data).await?;
+                    let mut tok_buf = Vec::with_capacity(data.len() + 4);
+                    token::send_data(&mut tok_buf, data).await?;
+                    mplex_out.write_data(&tok_buf).await?;
                     literal_bytes += data.len() as u64;
                 }
                 matcher::MatchOp::BlockMatch(block_idx) => {
-                    token::send_block_match(&mut resp_buf, *block_idx).await?;
+                    let mut tok_buf = Vec::with_capacity(8);
+                    token::send_block_match(&mut tok_buf, *block_idx).await?;
+                    mplex_out.write_data(&tok_buf).await?;
                     if sums.head.blength > 0 {
                         matched_bytes += sums.head.blength as u64;
                     }
                 }
             }
         }
-        token::send_eof(&mut resp_buf).await?;
+        let mut eof_buf = Vec::with_capacity(8);
+        token::send_eof(&mut eof_buf).await?;
+        mplex_out.write_data(&eof_buf).await?;
 
-        // File-level checksum.
+        // 3. File-level checksum.
         let file_sum = checksum::file_checksum(&source_data, seed, checksum_type);
-        resp_buf.extend_from_slice(&file_sum);
-
-        // Send the complete response as MUX DATA.
-        mplex_out.write_data(&resp_buf).await?;
+        mplex_out.write_data(&file_sum).await?;
         mplex_out.flush().await?;
 
         stats.files_transferred += 1;
@@ -621,15 +627,22 @@ where
             700
         };
 
-        // Read tokens + file checksum.
-        let result_data =
-            receiver::recv_file_delta(demux_read, &basis_data, blength, seed, checksum_type)
-                .await?;
+        // Read tokens, reconstruct file via streaming writer, verify checksum.
+        let mut output = Vec::new();
+        let bytes_written = receiver::recv_file_delta_to_writer(
+            demux_read,
+            &basis_data,
+            blength,
+            seed,
+            checksum_type,
+            &mut output,
+        )
+        .await?;
 
-        let literal_bytes = result_data.len() as u64;
+        let literal_bytes = bytes_written;
 
         // Write reconstructed file.
-        file_ops.write_file(entry, &result_data)?;
+        file_ops.write_file(entry, &output)?;
 
         // Set metadata.
         file_ops.set_metadata(entry);
@@ -648,6 +661,244 @@ where
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Pipelined receiver loop
+// ---------------------------------------------------------------------------
+
+/// Message from the generator task to the receiver task.
+enum GeneratorItem {
+    /// A file is being requested from the sender.
+    File {
+        entry_idx: usize,
+        basis_data: Vec<u8>,
+        blength: usize,
+    },
+    /// All phases are complete.
+    Done,
+}
+
+/// Run the receiver loop with pipelined generator/receiver tasks.
+///
+/// The generator task sends block signatures to the remote sender while
+/// the receiver task concurrently processes delta responses. This allows
+/// the generator to request file N+1 while the receiver is still
+/// reconstructing file N, matching rsync's 3-process architecture.
+///
+/// The `mplex_out` writer is owned exclusively by the generator task.
+/// The `demux_read` reader is owned exclusively by the receiver task.
+/// A bounded mpsc channel carries [`GeneratorItem`] messages from the
+/// generator to the receiver so it knows which file to expect next.
+#[allow(clippy::too_many_arguments)]
+pub async fn receiver_loop_pipelined<R, W>(
+    demux_read: R,
+    mplex_out: MplexWriter<W>,
+    entries: &[FileEntry],
+    entry_ndx: &[i32],
+    file_ops: Arc<dyn FileOps>,
+    protocol: &NegotiatedProtocol,
+    stats: &mut TransferStats,
+    progress: &mut ProgressTracker,
+) -> Result<(R, MplexWriter<W>)>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    let seed = protocol.seed;
+    let checksum_type = protocol.checksum;
+    let proto_ver = protocol.version;
+    let proper_seed_order = protocol.proper_seed_order;
+
+    // Create directories first (same as sequential loop).
+    for entry in entries {
+        if !entry.is_dir() {
+            continue;
+        }
+        file_ops.mkdir(entry)?;
+        stats.directories_created += 1;
+    }
+
+    // Pre-compute file items: (entry_idx, file_ndx, entry_clone).
+    // We clone entries that need transferring so they can be moved
+    // into the spawned tasks.
+    let mut file_items: Vec<(usize, i32, FileEntry)> = Vec::new();
+    for (idx, entry) in entries.iter().enumerate() {
+        if !entry.is_file() {
+            continue;
+        }
+        if file_ops.should_skip(entry) {
+            continue;
+        }
+        file_ops.ensure_parent(entry)?;
+        file_items.push((idx, entry_ndx[idx], entry.clone()));
+    }
+
+    // Bounded channel: generator -> receiver. Capacity of 4 provides
+    // enough pipelining without unbounded memory growth.
+    let (gen_tx, mut gen_rx) = tokio::sync::mpsc::channel::<GeneratorItem>(4);
+
+    // Clone data needed by the generator task.
+    let gen_file_items = file_items.clone();
+    let gen_file_ops = Arc::clone(&file_ops);
+
+    // --- Generator task ---
+    // Owns mplex_out exclusively. Reads basis files, computes signatures,
+    // sends them to the wire, and tells the receiver what's coming.
+    let generator_handle = tokio::spawn(async move {
+        let mut mplex_out = mplex_out;
+        let mut gen_ndx_state = varint::NdxState::default();
+
+        for (idx, file_ndx, entry) in &gen_file_items {
+            // Read existing basis file for delta computation.
+            let basis_data = gen_file_ops.read_basis(entry);
+
+            // Compute block signatures.
+            let sigs = sum::compute_signatures(
+                &basis_data,
+                seed,
+                checksum_type,
+                checksum::CHAR_OFFSET_V30,
+                proper_seed_order,
+            );
+
+            let blength = if sigs.head.blength > 0 {
+                sigs.head.blength as usize
+            } else {
+                700
+            };
+
+            // Send generator output to wire: NDX + iflags + sum_head + block sigs.
+            let mut sig_buf = Vec::new();
+            varint::write_ndx(&mut sig_buf, *file_ndx, &mut gen_ndx_state, proto_ver).await?;
+            if proto_ver >= 29 {
+                const ITEM_TRANSFER: u16 = 1 << 15;
+                varint::write_shortint(&mut sig_buf, ITEM_TRANSFER).await?;
+            }
+            sum::write_sums(&mut sig_buf, &sigs).await?;
+            mplex_out.write_data(&sig_buf).await?;
+            mplex_out.flush().await?;
+
+            // Tell receiver task what file to expect.
+            let item = GeneratorItem::File {
+                entry_idx: *idx,
+                basis_data,
+                blength,
+            };
+            if gen_tx.send(item).await.is_err() {
+                // Receiver dropped -- it hit an error.
+                break;
+            }
+        }
+
+        // Signal completion.
+        let _ = gen_tx.send(GeneratorItem::Done).await;
+
+        Ok::<MplexWriter<W>, WireError>(mplex_out)
+    });
+
+    // --- Receiver task (runs on current task) ---
+    // Owns demux_read exclusively. Reads GeneratorItems from the channel,
+    // then reads the sender's delta response from the wire.
+    let mut demux_read = demux_read;
+    let mut recv_ndx_state = varint::NdxState::default();
+
+    while let Some(item) = gen_rx.recv().await {
+        match item {
+            GeneratorItem::File {
+                entry_idx,
+                basis_data,
+                blength,
+            } => {
+                let entry = &entries[entry_idx];
+
+                progress.emit(ProgressEvent::FileStart {
+                    index: entry_idx as i32,
+                    name: crate::engine::progress::name_to_pathbuf(&entry.name),
+                    size: entry.len,
+                });
+
+                // Read sender's response NDX.
+                let _file_ndx =
+                    varint::read_ndx(&mut demux_read, &mut recv_ndx_state, proto_ver).await?;
+
+                // Read iflags (protocol >= 29).
+                if proto_ver >= 29 {
+                    let mut iflags_buf = [0u8; 2];
+                    demux_read.read_exact(&mut iflags_buf).await?;
+                    let iflags = u16::from_le_bytes(iflags_buf);
+
+                    if iflags & 0x0800 != 0 {
+                        let mut bt = [0u8; 1];
+                        demux_read.read_exact(&mut bt).await?;
+                    }
+                    if iflags & 0x1000 != 0 {
+                        let name_len = varint::read_varint(&mut demux_read).await?;
+                        if name_len > 0x10000 {
+                            return Err(WireError::Protocol(
+                                ProtocolError::WireValueOutOfRange {
+                                    field: "xname_len",
+                                    value: name_len as i64,
+                                    max: 0x10000,
+                                },
+                            ));
+                        }
+                        let mut name_buf = vec![0u8; name_len as usize];
+                        demux_read.read_exact(&mut name_buf).await?;
+                    }
+                }
+
+                // Read sum_head from sender.
+                let sum_head = sum::read_sum_head(&mut demux_read).await?;
+                let blength_actual = if sum_head.blength > 0 {
+                    sum_head.blength as usize
+                } else {
+                    blength
+                };
+
+                // Reconstruct file via streaming writer.
+                let mut output = Vec::new();
+                let bytes_written = receiver::recv_file_delta_to_writer(
+                    &mut demux_read,
+                    &basis_data,
+                    blength_actual,
+                    seed,
+                    checksum_type,
+                    &mut output,
+                )
+                .await?;
+
+                let literal_bytes = bytes_written;
+
+                // Write reconstructed file.
+                file_ops.write_file(entry, &output)?;
+                file_ops.set_metadata(entry);
+
+                stats.files_transferred += 1;
+                stats.total_size += entry.len as u64;
+                stats.literal_data += literal_bytes;
+                stats.bytes_received += literal_bytes;
+
+                progress.emit(ProgressEvent::FileComplete {
+                    index: entry_idx as i32,
+                    name: crate::engine::progress::name_to_pathbuf(&entry.name),
+                    literal_bytes,
+                    matched_bytes: 0,
+                });
+            }
+            GeneratorItem::Done => break,
+        }
+    }
+
+    // Wait for generator task to complete and recover mplex_out.
+    // We need mplex_out back for the phase exchange that follows.
+    let mplex_out = generator_handle.await.map_err(|e| {
+        WireError::Protocol(ProtocolError::Handshake {
+            message: format!("generator task panicked: {e}"),
+        })
+    })??;
+
+    Ok((demux_read, mplex_out))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ferrosync-core/src/server/session.rs
+++ b/crates/ferrosync-core/src/server/session.rs
@@ -177,22 +177,24 @@ impl ServerSession {
         );
 
         #[cfg(unix)]
-        let fs = crate::fs::unix::UnixFileSystem::new();
+        let fs: std::sync::Arc<dyn crate::fs::FileSystem> =
+            std::sync::Arc::new(crate::fs::unix::UnixFileSystem::new());
         #[cfg(windows)]
-        let fs = crate::fs::windows::WindowsFileSystem::new();
+        let fs: std::sync::Arc<dyn crate::fs::FileSystem> =
+            std::sync::Arc::new(crate::fs::windows::WindowsFileSystem::new());
 
         let mut progress = self.progress;
 
         match self.direction {
             TransferDirection::Send => {
                 Self::handle_send_impl(
-                    &self.module, reader, writer, &protocol, &fs, &opts, &mut progress,
+                    &self.module, reader, writer, &protocol, &*fs, &opts, &mut progress,
                 )
                 .await
             }
             TransferDirection::Receive => {
                 Self::handle_receive_impl(
-                    &self.module, reader, writer, &protocol, &fs, &opts, &mut progress,
+                    &self.module, reader, writer, &protocol, fs, &opts, &mut progress,
                 )
                 .await
             }
@@ -293,13 +295,13 @@ impl ServerSession {
         reader: R,
         writer: W,
         protocol: &NegotiatedProtocol,
-        fs: &dyn FileSystem,
+        fs: std::sync::Arc<dyn FileSystem>,
         opts: &TransferOptions,
         progress: &mut ProgressTracker,
     ) -> Result<(), SessionError>
     where
         R: AsyncRead + Unpin + Send + 'static,
-        W: AsyncWrite + Unpin + Send,
+        W: AsyncWrite + Unpin + Send + 'static,
     {
         if module.read_only {
             return Err(SessionError::Protocol {
@@ -314,8 +316,8 @@ impl ServerSession {
 
         // Enable multiplexing.
         // Uses unbounded channel demux to prevent bidirectional deadlock.
-        let (mut demux_read, demux_handle) = start_demux(reader);
-        let mut mplex_out = MplexWriter::new(writer);
+        let (demux_read, demux_handle) = start_demux(reader);
+        let mplex_out = MplexWriter::new(writer);
 
         // Read and discard the client's filter list -- CONDITIONAL.
         //
@@ -324,6 +326,8 @@ impl ServerSession {
         // For server receiver: am_sender=0, receiver_wants_list = delete || prune.
         // Client only sends filter list when delete_mode is active (see session.rs).
         let expect_filter_list = opts.delete() != crate::options::DeleteMode::None;
+        let mut demux_read = demux_read;
+        let mut mplex_out = mplex_out;
         if expect_filter_list {
             read_and_discard_filter_list(&mut demux_read).await?;
         }
@@ -337,22 +341,25 @@ impl ServerSession {
         let entries = received_flist.entries;
         let entry_ndx = received_flist.entry_ndx;
 
-        // Receiver loop via wire_transfer.
-        let file_ops = ModuleFileOps::new(fs, &module.path);
+        // Pipelined receiver loop via wire_transfer.
+        let file_ops: std::sync::Arc<dyn wire_transfer::FileOps> =
+            std::sync::Arc::new(ModuleFileOps::new(fs, module.path.clone()));
         let mut stats = TransferStats::new();
         stats.start();
 
-        wire_transfer::receiver_loop(
-            &mut demux_read,
-            &mut mplex_out,
+        let (dr, mo) = wire_transfer::receiver_loop_pipelined(
+            demux_read,
+            mplex_out,
             &entries,
             &entry_ndx,
-            &file_ops,
+            file_ops,
             protocol,
             &mut stats,
             progress,
         )
         .await?;
+        demux_read = dr;
+        mplex_out = mo;
 
         // Phase exchange.
         wire_transfer::server_receiver_phase_exchange(

--- a/crates/ferrosync-core/tests/e2e.rs
+++ b/crates/ferrosync-core/tests/e2e.rs
@@ -426,6 +426,179 @@ async fn test_e2e_push_archive_mode() {
     assert_eq!(pushed, content);
 }
 
+// ---------------------------------------------------------------------------
+// Pipelining stress tests
+//
+// These tests exercise the concurrent generator/receiver pipeline by
+// transferring many files (where the generator can send signatures for
+// file N+1 while the receiver is still processing file N's delta).
+// ---------------------------------------------------------------------------
+
+/// Pull many small files to exercise generator/receiver pipelining.
+#[tokio::test]
+async fn test_e2e_pull_many_small_files() {
+    let server_dir = tempfile::tempdir().unwrap();
+    let client_dir = tempfile::tempdir().unwrap();
+
+    // Create 50 small files on the server.
+    let file_count = 50;
+    for i in 0..file_count {
+        let content = format!("file {i} content -- small file pipelining test\n");
+        std::fs::write(
+            server_dir.path().join(format!("file_{i:03}.txt")),
+            content.as_bytes(),
+        )
+        .unwrap();
+    }
+
+    let (addr, shutdown) = start_test_server(server_dir.path(), true).await;
+    ferrosync_client_pull(addr, "test", client_dir.path()).await;
+    let _ = shutdown.send(true);
+
+    // Verify all files arrived correctly.
+    for i in 0..file_count {
+        let expected = format!("file {i} content -- small file pipelining test\n");
+        let actual = std::fs::read(client_dir.path().join(format!("file_{i:03}.txt"))).unwrap();
+        assert_eq!(actual, expected.as_bytes(), "mismatch for file_{i:03}.txt");
+    }
+}
+
+/// Push many small files to exercise server-side pipelined receiver.
+#[tokio::test]
+async fn test_e2e_push_many_small_files() {
+    let server_dir = tempfile::tempdir().unwrap();
+    let client_dir = tempfile::tempdir().unwrap();
+
+    // Create 50 small files on the client.
+    let file_count = 50;
+    for i in 0..file_count {
+        let content = format!("pushed file {i}\n");
+        std::fs::write(
+            client_dir.path().join(format!("push_{i:03}.txt")),
+            content.as_bytes(),
+        )
+        .unwrap();
+    }
+
+    let (addr, shutdown) = start_test_server(server_dir.path(), false).await;
+    ferrosync_client_push(addr, "test", client_dir.path()).await;
+    let _ = shutdown.send(true);
+
+    for i in 0..file_count {
+        let expected = format!("pushed file {i}\n");
+        let actual = std::fs::read(server_dir.path().join(format!("push_{i:03}.txt"))).unwrap();
+        assert_eq!(actual, expected.as_bytes(), "mismatch for push_{i:03}.txt");
+    }
+}
+
+/// Pull a mix of large and small files to stress the pipeline with
+/// varied per-file processing times.
+#[tokio::test]
+async fn test_e2e_pull_mixed_file_sizes() {
+    let server_dir = tempfile::tempdir().unwrap();
+    let client_dir = tempfile::tempdir().unwrap();
+
+    // Small files interspersed with larger ones.
+    std::fs::write(server_dir.path().join("tiny_1.txt"), b"a").unwrap();
+    let medium: Vec<u8> = (0..8192).map(|i| (i % 251) as u8).collect();
+    std::fs::write(server_dir.path().join("medium.bin"), &medium).unwrap();
+    std::fs::write(server_dir.path().join("tiny_2.txt"), b"bb").unwrap();
+    let large: Vec<u8> = (0..128 * 1024).map(|i| (i % 199) as u8).collect();
+    std::fs::write(server_dir.path().join("large.bin"), &large).unwrap();
+    std::fs::write(server_dir.path().join("tiny_3.txt"), b"ccc").unwrap();
+    std::fs::write(server_dir.path().join("empty.dat"), b"").unwrap();
+
+    let (addr, shutdown) = start_test_server(server_dir.path(), true).await;
+    ferrosync_client_pull(addr, "test", client_dir.path()).await;
+    let _ = shutdown.send(true);
+
+    assert_eq!(
+        std::fs::read(client_dir.path().join("tiny_1.txt")).unwrap(),
+        b"a"
+    );
+    assert_eq!(
+        std::fs::read(client_dir.path().join("medium.bin")).unwrap(),
+        medium
+    );
+    assert_eq!(
+        std::fs::read(client_dir.path().join("tiny_2.txt")).unwrap(),
+        b"bb"
+    );
+    assert_eq!(
+        std::fs::read(client_dir.path().join("large.bin")).unwrap(),
+        large
+    );
+    assert_eq!(
+        std::fs::read(client_dir.path().join("tiny_3.txt")).unwrap(),
+        b"ccc"
+    );
+    assert_eq!(
+        std::fs::read(client_dir.path().join("empty.dat")).unwrap(),
+        b""
+    );
+}
+
+/// Pull with delta: many files where the basis already exists at the
+/// destination. Exercises pipelining with non-trivial block matching.
+#[tokio::test]
+async fn test_e2e_pull_many_files_delta() {
+    let server_dir = tempfile::tempdir().unwrap();
+    let client_dir = tempfile::tempdir().unwrap();
+
+    let file_count = 20;
+    for i in 0..file_count {
+        // Create basis on client (old version).
+        let mut basis = vec![0u8; 4096];
+        for (j, b) in basis.iter_mut().enumerate() {
+            *b = ((i + j) % 256) as u8;
+        }
+        std::fs::write(
+            client_dir.path().join(format!("delta_{i:02}.bin")),
+            &basis,
+        )
+        .unwrap();
+
+        // Create modified version on server.
+        let mut modified = basis.clone();
+        modified[2048] = 0xFF;
+        modified[2049] = 0xFE;
+        std::fs::write(
+            server_dir.path().join(format!("delta_{i:02}.bin")),
+            &modified,
+        )
+        .unwrap();
+        // Set future mtime so quick-check detects the change.
+        let future = filetime::FileTime::from_unix_time(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64
+                + 200,
+            0,
+        );
+        filetime::set_file_mtime(
+            server_dir.path().join(format!("delta_{i:02}.bin")),
+            future,
+        )
+        .unwrap();
+    }
+
+    let (addr, shutdown) = start_test_server(server_dir.path(), true).await;
+    ferrosync_client_pull(addr, "test", client_dir.path()).await;
+    let _ = shutdown.send(true);
+
+    for i in 0..file_count {
+        let mut expected = vec![0u8; 4096];
+        for (j, b) in expected.iter_mut().enumerate() {
+            *b = ((i + j) % 256) as u8;
+        }
+        expected[2048] = 0xFF;
+        expected[2049] = 0xFE;
+        let actual = std::fs::read(client_dir.path().join(format!("delta_{i:02}.bin"))).unwrap();
+        assert_eq!(actual, expected, "mismatch for delta_{i:02}.bin");
+    }
+}
+
 /// Pull with archive mode to exercise uid/gid name list decoding.
 #[tokio::test]
 async fn test_e2e_pull_archive_mode() {

--- a/crates/ferrosync-core/tests/rsync_compat.rs
+++ b/crates/ferrosync-core/tests/rsync_compat.rs
@@ -511,6 +511,80 @@ async fn test_transfer_symlink() {
 }
 
 #[tokio::test]
+async fn test_transfer_many_small_files() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::create_dir_all(&dst).unwrap();
+
+    // Create 100 small files.
+    for i in 0..100 {
+        let content = format!("file number {i}\n");
+        std::fs::write(src.join(format!("f_{i:03}.txt")), content.as_bytes()).unwrap();
+    }
+
+    let options = TransferOptions::builder()
+        .recursive(true)
+        .preserve_times(true)
+        .source(src.clone())
+        .dest(dst.clone())
+        .build();
+
+    run_transfer(&options).await.unwrap();
+
+    for i in 0..100 {
+        let expected = format!("file number {i}\n");
+        let actual = std::fs::read(dst.join(format!("f_{i:03}.txt"))).unwrap();
+        assert_eq!(actual, expected.as_bytes(), "mismatch for f_{i:03}.txt");
+    }
+}
+
+#[tokio::test]
+async fn test_transfer_many_files_delta() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::create_dir_all(&dst).unwrap();
+
+    // Create basis files at dest and modified versions at source.
+    for i in 0..30 {
+        let mut basis = vec![0u8; 4096];
+        for (j, b) in basis.iter_mut().enumerate() {
+            *b = ((i * 7 + j) % 256) as u8;
+        }
+        std::fs::write(dst.join(format!("d_{i:02}.bin")), &basis).unwrap();
+
+        let mut modified = basis;
+        modified[1024] = 0xFF;
+        modified[1025] = 0xFE;
+        std::fs::write(src.join(format!("d_{i:02}.bin")), &modified).unwrap();
+    }
+
+    let options = TransferOptions::builder()
+        .recursive(true)
+        .preserve_times(true)
+        .checksum_mode(true)
+        .source(src.clone())
+        .dest(dst.clone())
+        .build();
+
+    run_transfer(&options).await.unwrap();
+
+    for i in 0..30 {
+        let mut expected = vec![0u8; 4096];
+        for (j, b) in expected.iter_mut().enumerate() {
+            *b = ((i * 7 + j) % 256) as u8;
+        }
+        expected[1024] = 0xFF;
+        expected[1025] = 0xFE;
+        let actual = std::fs::read(dst.join(format!("d_{i:02}.bin"))).unwrap();
+        assert_eq!(actual, expected, "mismatch for d_{i:02}.bin");
+    }
+}
+
+#[tokio::test]
 async fn test_transfer_special_characters_in_filenames() {
     let tmp = tempfile::tempdir().unwrap();
     let src = tmp.path().join("src");


### PR DESCRIPTION
## Summary

- **Stream sender tokens directly to wire** -- eliminate O(file_size) intermediate buffer per file in sender_loop; header, tokens, and checksum written as individual MUX frames
- **Incremental checksum + streaming receiver** -- add `IncrementalChecksum` (md4/md5/blake3/xxh3/xxh128) and `recv_file_delta_to_writer()` for computing file checksums without full-file buffering
- **Generator/receiver pipelining** -- split receiver_loop into concurrent generator (tokio::spawn, owns mplex_out) and receiver (current task, owns demux_read) connected by bounded mpsc channel (capacity 4), matching rsync's 3-process architecture

Addresses #74, #84, lays foundation for #81.

## Changes

| File | Change |
|------|--------|
| `delta/checksum.rs` | `IncrementalChecksum` enum with `update()`/`finalize()` |
| `engine/receiver.rs` | `recv_file_delta_to_writer()` streaming variant |
| `engine/wire_transfer.rs` | Streaming sender, `receiver_loop_pipelined()`, owned `LocalFileOps`/`ModuleFileOps` |
| `engine/session.rs` | Switch to pipelined receiver, `Arc<dyn FileSystem>` |
| `server/session.rs` | Switch to pipelined receiver, `Arc<dyn FileSystem>` |
| `tests/e2e.rs` | 4 new pipelining stress tests (many files, mixed sizes, delta) |
| `tests/rsync_compat.rs` | 2 new multi-file transfer tests |

## Test plan

- [x] 455 unit tests pass
- [x] 14 e2e tests pass (4 new pipelining tests)
- [x] 19 rsync_compat tests pass (2 new multi-file tests)
- [x] Zero clippy warnings
- [ ] `RSYNC_BIN=/tmp/rsync-3.4.1/rsync cargo test rsync_interop` -- interop against real rsync
- [ ] `FERROSYNC_SSH_TEST=1 cargo test ssh_interop` -- SSH end-to-end
- [ ] Manual test: `ferrosync -rav` a directory with many files over SSH